### PR TITLE
Make section page width relative to linewidth

### DIFF
--- a/source/beamerinnerthememetropolis.dtx
+++ b/source/beamerinnerthememetropolis.dtx
@@ -265,7 +265,7 @@
 }
 \defbeamertemplate{section page}{progressbar}{
   \centering
-  \begin{minipage}{22em}
+  \begin{minipage}{0.7875\linewidth}
     \raggedright
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}


### PR DESCRIPTION
Because the minipage width of the section page was hard coded to 22em, the proportions did not look quite right (at least to me) when using, for instance, "aspectratio=169" in a presentation.  Making the size of the minipage a fraction of the linewidth preserves the proportions and looks better to me.  This PR only proposes that change.  What follows is simply my calculations, so someone can spot a mistake and correct me if there is one.

I looked into the beamer.cls file and found that the slide width for the 4:3 aspect ratio is 12.8cm.  Beamer uses the geometry package to set the left and right horizontal margins to 1cm.  Thus, the linewidth is 10.8cm.

The default font size is 11pt.  Using TeX's definition of a point (i.e. ~0.035146cm) and the fact that an em is equal to the font size in pt, converting 22em in cm gave me ~8.505cm which translates to 0.787\linewidth based on the measurements above.